### PR TITLE
In format selection: Show resolution and download size (if available)

### DIFF
--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -387,6 +387,7 @@ export default function Home({ socket }: Props) {
                       setPickedAudioFormat('')
                     }}>
                     {downloadFormats.best.format_note || downloadFormats.best.format_id} - {downloadFormats.best.vcodec}+{downloadFormats.best.acodec}
+                    &nbsp;({downloadFormats.best.resolution}{(downloadFormats.best.filesize_approx>0)?", ~"+Math.round(downloadFormats.best.filesize_approx/1024/1024)+" MiB":""})
                   </Button>
                 </Grid>
                 {/* video only */}
@@ -411,6 +412,7 @@ export default function Home({ socket }: Props) {
                         disabled={pickedVideoFormat === format.format_id}
                       >
                         {format.format_note} - {format.vcodec === 'none' ? format.acodec : format.vcodec}
+                        &nbsp;({format.resolution}{(format.filesize_approx>0)?", ~"+Math.round(format.filesize_approx/1024/1024)+" MiB":""})
                       </Button>
                     </Grid>
                   ))
@@ -436,6 +438,7 @@ export default function Home({ socket }: Props) {
                         disabled={pickedAudioFormat === format.format_id}
                       >
                         {format.format_note} - {format.vcodec === 'none' ? format.acodec : format.vcodec}
+                        {(format.filesize_approx>0)?" (~"+Math.round(format.filesize_approx/1024/1024)+" MiB)":""}
                       </Button>
                     </Grid>
                   ))

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -59,4 +59,5 @@ export interface IDLFormat {
   resolution: string,
   vcodec: string,
   acodec: string,
+  filesize_approx: number,
 }

--- a/server/types.go
+++ b/server/types.go
@@ -36,6 +36,7 @@ type Format struct {
 	Resolution  string  `json:"resolution"`
 	VCodec      string  `json:"vcodec"`
 	ACodec      string  `json:"acodec"`
+	Size        float32 `json:"filesize_approx"`
 }
 
 // struct representing the response sent to the client


### PR DESCRIPTION
I added some code to show (in the video/best section) the resolution. Additionally, if a value greater zero is passed, the estimated download size of the format is added, too.