### PR TITLE
If formats selection enabled: Show "select format" string in button

### DIFF
--- a/frontend/src/Home.tsx
+++ b/frontend/src/Home.tsx
@@ -335,7 +335,7 @@ export default function Home({ socket }: Props) {
                   disabled={url === ''}
                   onClick={() => settings.formatSelection ? sendUrlFormatSelection() : sendUrl()}
                 >
-                  {i18n.t('startButton')}
+                  {settings.formatSelection ? i18n.t('selectFormatButton') : i18n.t('startButton')}
                 </Button>
               </Grid>
               <Grid item>

--- a/frontend/src/assets/i18n.yaml
+++ b/frontend/src/assets/i18n.yaml
@@ -4,6 +4,7 @@ languages:
     urlInput: YouTube or other supported service video URL
     statusTitle: Status
     statusReady: Ready
+    selectFormatButton: Select format
     startButton: Start
     abortAllButton: Abort All
     updateBinButton: Update yt-dlp binary


### PR DESCRIPTION
I want to select the downloaded formats (to conserve space). I found it irritating that after enabling the option, the button below the URL still showed "start". I added a new i18n label for "select format", which is used if the option is enabled.