### PR TITLE
Fix WebSocket protocol detecton under HTTPS

### DIFF
--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -74,7 +74,8 @@ export function toFormatArgs(codes: string[]): string {
 }
 
 export function getWebSocketEndpoint() {
-    return `ws://${localStorage.getItem('server-addr') || window.location.hostname}:${localStorage.getItem('server-port') || window.location.port}/ws-rpc`
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws'
+    return `${protocol}://${localStorage.getItem('server-addr') || window.location.hostname}:${localStorage.getItem('server-port') || window.location.port}/ws-rpc`
 }
 
 export function getHttpRPCEndpoint() {


### PR DESCRIPTION
As title.

Fix `Mixed Content: The page at 'https://blah.com/' was loaded over HTTPS, but attempted to connect to the insecure WebSocket endpoint 'ws://blah.com/ws-rpc'. This request has been blocked; this endpoint must be available over WSS.` by detecting protocol.