### PR TITLE
Download REST API endpoints

### DIFF
--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -1,14 +1,11 @@
 import { ThemeProvider } from '@emotion/react'
-
 import ChevronLeft from '@mui/icons-material/ChevronLeft'
 import Dashboard from '@mui/icons-material/Dashboard'
 import Menu from '@mui/icons-material/Menu'
 import SettingsIcon from '@mui/icons-material/Settings'
 import SettingsEthernet from '@mui/icons-material/SettingsEthernet'
 import Storage from '@mui/icons-material/Storage'
-
 import { Box, createTheme } from '@mui/material'
-
 import DownloadIcon from '@mui/icons-material/Download'
 import CssBaseline from '@mui/material/CssBaseline'
 import Divider from '@mui/material/Divider'
@@ -19,20 +16,16 @@ import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
 import Toolbar from '@mui/material/Toolbar'
 import Typography from '@mui/material/Typography'
-
 import { grey } from '@mui/material/colors'
-
 import { useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
-
 import { Link, Outlet } from 'react-router-dom'
 import { RootState } from './stores/store'
-
 import AppBar from './components/AppBar'
 import Drawer from './components/Drawer'
-
 import Logout from './components/Logout'
 import ThemeToggler from './components/ThemeToggler'
+import Toaster from './providers/ToasterProvider'
 import I18nProvider from './providers/i18nProvider'
 import RPCClientProvider from './providers/rpcClientProvider'
 import { formatGiB } from './utils'
@@ -184,6 +177,7 @@ export default function Layout() {
               <Outlet />
             </Box>
           </Box>
+          <Toaster />
         </RPCClientProvider>
       </I18nProvider>
     </ThemeProvider>

--- a/frontend/src/components/DownloadsCardView.tsx
+++ b/frontend/src/components/DownloadsCardView.tsx
@@ -1,8 +1,9 @@
-import { Grid, Snackbar } from "@mui/material"
-import { Fragment, useContext, useEffect, useState } from "react"
+import { Grid } from "@mui/material"
+import { Fragment, useContext } from "react"
+import { useToast } from "../hooks/toast"
+import { I18nContext } from "../providers/i18nProvider"
 import type { RPCResult } from "../types"
 import { StackableResult } from "./StackableResult"
-import { I18nContext } from "../providers/i18nProvider"
 
 type Props = {
   downloads: RPCResult[]
@@ -10,9 +11,8 @@ type Props = {
 }
 
 export function DownloadsCardView({ downloads, onStop }: Props) {
-  const [openSB, setOpenSB] = useState(false)
-
   const { i18n } = useContext(I18nContext)
+  const { pushMessage } = useToast()
 
   return (
     <Grid container spacing={{ xs: 2, md: 2 }} columns={{ xs: 4, sm: 8, md: 12 }} pt={2}>
@@ -26,7 +26,7 @@ export function DownloadsCardView({ downloads, onStop }: Props) {
                 thumbnail={download.info.thumbnail}
                 percentage={download.progress.percentage}
                 onStop={() => onStop(download.id)}
-                onCopy={() => setOpenSB(true)}
+                onCopy={() => pushMessage(i18n.t('clipboardAction'))}
                 resolution={download.info.resolution ?? ''}
                 speed={download.progress.speed}
                 size={download.info.filesize_approx ?? 0}
@@ -36,12 +36,6 @@ export function DownloadsCardView({ downloads, onStop }: Props) {
           </Grid>
         ))
       }
-      <Snackbar
-        open={openSB}
-        autoHideDuration={1250}
-        onClose={() => setOpenSB(false)}
-        message={i18n.t('clipboardAction')}
-      />
     </Grid>
   )
 }

--- a/frontend/src/components/DownloadsListView.tsx
+++ b/frontend/src/components/DownloadsListView.tsx
@@ -19,13 +19,13 @@ type Props = {
   onStop: (id: string) => void
 }
 
-export function DownloadsListView({ downloads, onStop }: Props) {
+export const DownloadsListView: React.FC<Props> = ({ downloads, onStop }) => {
   return (
     <Grid container spacing={{ xs: 2, md: 2 }} columns={{ xs: 4, sm: 8, md: 12 }} pt={2}>
       <Grid item xs={12}>
-        <TableContainer component={Paper} sx={{ minHeight: '80vh' }} elevation={2}>
+        <TableContainer component={Paper} sx={{ minHeight: '100%' }} elevation={2}>
           <Table>
-            <TableHead>
+            <TableHead hidden={downloads.length === 0}>
               <TableRow>
                 <TableCell>
                   <Typography fontWeight={500} fontSize={15}>Title</Typography>
@@ -52,8 +52,9 @@ export function DownloadsListView({ downloads, onStop }: Props) {
                     <TableCell>
                       <LinearProgress
                         value={
-                          download.progress.percentage === '-1' ? 100 :
-                            Number(download.progress.percentage.replace('%', ''))
+                          download.progress.percentage === '-1'
+                            ? 100
+                            : Number(download.progress.percentage.replace('%', ''))
                         }
                         variant={
                           download.progress.process_status === 0

--- a/frontend/src/features/ui/toastSlice.ts
+++ b/frontend/src/features/ui/toastSlice.ts
@@ -1,0 +1,46 @@
+import { AlertColor } from '@mui/material'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+export interface ToastState {
+  message: string
+  open: boolean
+  autoClose: boolean
+  severity?: AlertColor
+}
+
+type MessageAction = {
+  message: string,
+  severity?: AlertColor
+}
+
+const initialState: ToastState = {
+  message: '',
+  open: false,
+  autoClose: true,
+}
+
+export const toastSlice = createSlice({
+  name: 'toast',
+  initialState,
+  reducers: {
+    setMessage: (state, action: PayloadAction<MessageAction>) => {
+      state.message = action.payload.message
+      state.severity = action.payload.severity
+      state.open = true
+    },
+    setOpen: (state) => {
+      state.open = true
+    },
+    setClose: (state) => {
+      state.open = false
+    },
+  }
+})
+
+export const {
+  setMessage,
+  setClose,
+  setOpen,
+} = toastSlice.actions
+
+export default toastSlice.reducer

--- a/frontend/src/hooks/toast.ts
+++ b/frontend/src/hooks/toast.ts
@@ -1,0 +1,16 @@
+import { useDispatch } from "react-redux"
+import { setMessage } from "../features/ui/toastSlice"
+import { AlertColor } from "@mui/material"
+
+export const useToast = () => {
+  const dispatch = useDispatch()
+
+  return {
+    pushMessage: (message: string, severity?: AlertColor) => {
+      dispatch(setMessage({
+        message: message,
+        severity: severity
+      }))
+    }
+  }
+}

--- a/frontend/src/providers/ToasterProvider.tsx
+++ b/frontend/src/providers/ToasterProvider.tsx
@@ -1,0 +1,23 @@
+import { Alert, Snackbar } from "@mui/material"
+import { useDispatch, useSelector } from "react-redux"
+import { setClose } from "../features/ui/toastSlice"
+import { RootState } from "../stores/store"
+
+const Toaster: React.FC = () => {
+  const toast = useSelector((state: RootState) => state.toast)
+  const dispatch = useDispatch()
+
+  return (
+    <Snackbar
+      open={toast.open}
+      autoHideDuration={toast.severity === 'error' ? 10000 : 1500}
+      onClose={() => dispatch(setClose())}
+    >
+      <Alert variant="filled" severity={toast.severity}>
+        {toast.message}
+      </Alert>
+    </Snackbar>
+  )
+}
+
+export default Toaster

--- a/frontend/src/stores/store.ts
+++ b/frontend/src/stores/store.ts
@@ -1,12 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit'
 import settingsReducer from '../features/settings/settingsSlice'
 import statussReducer from '../features/status/statusSlice'
+import toastReducer from '../features/ui/toastSlice'
 
 export const store = configureStore({
-    reducer: {
-        settings: settingsReducer,
-        status: statussReducer,
-    },
+  reducer: {
+    settings: settingsReducer,
+    status: statussReducer,
+    toast: toastReducer,
+  },
 })
 
 export type RootState = ReturnType<typeof store.getState>

--- a/frontend/src/views/Settings.tsx
+++ b/frontend/src/views/Settings.tsx
@@ -11,7 +11,6 @@ import {
   Paper,
   Select,
   SelectChangeEvent,
-  Snackbar,
   Stack,
   Switch,
   TextField,
@@ -39,7 +38,7 @@ import {
   setServerPort,
   setTheme
 } from '../features/settings/settingsSlice'
-import { updated } from '../features/status/statusSlice'
+import { useToast } from '../hooks/toast'
 import { CliArguments } from '../lib/argsParser'
 import { I18nContext } from '../providers/i18nProvider'
 import { RPCClientContext } from '../providers/rpcClientProvider'
@@ -49,13 +48,14 @@ import { validateDomain, validateIP } from '../utils'
 export default function Settings() {
   const dispatch = useDispatch()
 
-  const status = useSelector((state: RootState) => state.status)
   const settings = useSelector((state: RootState) => state.settings)
 
   const [invalidIP, setInvalidIP] = useState(false);
 
   const { i18n } = useContext(I18nContext)
   const { client } = useContext(RPCClientContext)
+
+  const { pushMessage } = useToast()
 
   const cliArgs = useMemo(() => new CliArguments().fromString(settings.cliArgs), [])
 
@@ -110,10 +110,10 @@ export default function Settings() {
   }
 
   /**
-   * Send via WebSocket a message to update yt-dlp binary
+   * Updates yt-dlp binary via RPC
    */
   const updateBinary = () => {
-    client.updateExecutable().then(() => dispatch(updated()))
+    client.updateExecutable().then(() => pushMessage(i18n.t('toastUpdated')))
   }
 
   return (
@@ -270,7 +270,7 @@ export default function Settings() {
                   <Button
                     sx={{ mr: 1, mt: 3 }}
                     variant="contained"
-                    onClick={() => dispatch(updated())}
+                    onClick={() => updateBinary()}
                   >
                     {i18n.t('updateBinButton')}
                   </Button>
@@ -280,12 +280,6 @@ export default function Settings() {
           </Paper>
         </Grid>
       </Grid>
-      <Snackbar
-        open={status.updated}
-        autoHideDuration={1500}
-        message={i18n.t('toastUpdated')}
-        onClose={updateBinary}
-      />
     </Container>
   );
 }

--- a/server/cli/ascii.go
+++ b/server/cli/ascii.go
@@ -1,7 +1,5 @@
 package cli
 
-import "fmt"
-
 const (
 	// FG
 	Red     = "\033[31m"
@@ -12,12 +10,8 @@ const (
 	Cyan    = "\033[36m"
 	Reset   = "\033[0m"
 	// BG
-	BgRed   = "\033[1;41m"
-	BgBlue  = "\033[1;44m"
-	BgGreen = "\033[1;42m"
+	BgRed     = "\033[1;41m"
+	BgBlue    = "\033[1;44m"
+	BgGreen   = "\033[1;42m"
+	BgMagenta = "\033[1;45m"
 )
-
-// Formats a message with the specified ascii escape code, then reset.
-func Format(message string, code string) string {
-	return fmt.Sprintf("%s%s%s", code, message, Reset)
-}

--- a/server/handlers/archive.go
+++ b/server/handlers/archive.go
@@ -1,0 +1,157 @@
+package handlers
+
+import (
+	"encoding/hex"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/goccy/go-json"
+	"github.com/marcopeocchi/yt-dlp-web-ui/server/config"
+	"github.com/marcopeocchi/yt-dlp-web-ui/server/utils"
+)
+
+const (
+	TOKEN_COOKIE_NAME = "jwt"
+)
+
+type DirectoryEntry struct {
+	Name        string    `json:"name"`
+	Path        string    `json:"path"`
+	Size        int64     `json:"size"`
+	SHASum      string    `json:"shaSum"`
+	ModTime     time.Time `json:"modTime"`
+	IsVideo     bool      `json:"isVideo"`
+	IsDirectory bool      `json:"isDirectory"`
+}
+
+func walkDir(root string) (*[]DirectoryEntry, error) {
+	files := []DirectoryEntry{}
+
+	dirs, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, d := range dirs {
+		if !utils.IsValidEntry(d) {
+			continue
+		}
+
+		path := filepath.Join(root, d.Name())
+
+		info, err := d.Info()
+		if err != nil {
+			return nil, err
+		}
+
+		files = append(files, DirectoryEntry{
+			Path:        path,
+			Name:        d.Name(),
+			Size:        info.Size(),
+			SHASum:      utils.ShaSumString(path),
+			IsVideo:     utils.IsVideo(d),
+			IsDirectory: d.IsDir(),
+			ModTime:     info.ModTime(),
+		})
+	}
+
+	return &files, err
+}
+
+type ListRequest struct {
+	SubDir  string `json:"subdir"`
+	OrderBy string `json:"orderBy"`
+}
+
+func ListDownloaded(w http.ResponseWriter, r *http.Request) {
+	root := config.Instance().GetConfig().DownloadPath
+	req := new(ListRequest)
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	files, err := walkDir(filepath.Join(root, req.SubDir))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if req.OrderBy == "modtime" {
+		sort.SliceStable(*files, func(i, j int) bool {
+			return (*files)[i].ModTime.After((*files)[j].ModTime)
+		})
+	}
+
+	w.WriteHeader(http.StatusOK)
+	err = json.NewEncoder(w).Encode(files)
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+type DeleteRequest = DirectoryEntry
+
+func DeleteFile(w http.ResponseWriter, r *http.Request) {
+	req := new(DeleteRequest)
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	sum := utils.ShaSumString(req.Path)
+	if sum != req.SHASum {
+		http.Error(w, "shasum mismatch", http.StatusBadRequest)
+		return
+	}
+
+	err = os.Remove(req.Path)
+	if err != nil {
+		http.Error(w, "shasum mismatch", http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode("ok")
+}
+
+func SendFile(w http.ResponseWriter, r *http.Request) {
+	path := chi.URLParam(r, "id")
+
+	if path == "" {
+		http.Error(w, "inexistent path", http.StatusBadRequest)
+		return
+	}
+
+	decoded, err := hex.DecodeString(path)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	decodedStr := string(decoded)
+
+	root := config.Instance().GetConfig().DownloadPath
+
+	// TODO: further path / file validations
+	if strings.Contains(filepath.Dir(decodedStr), root) {
+		// ctx.Response().Header.Set(
+		// 	"Content-Disposition",
+		// 	"inline; filename="+filepath.Base(decodedStr),
+		// )
+
+		http.ServeFile(w, r, decodedStr)
+	}
+
+	w.WriteHeader(http.StatusUnauthorized)
+}

--- a/server/handlers/login.go
+++ b/server/handlers/login.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/goccy/go-json"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/marcopeocchi/yt-dlp-web-ui/server/config"
+)
+
+type LoginRequest struct {
+	Secret string `json:"secret"`
+}
+
+func Login(w http.ResponseWriter, r *http.Request) {
+	req := new(LoginRequest)
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if config.Instance().GetConfig().RPCSecret != req.Secret {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	expiresAt := time.Now().Add(time.Hour * 24 * 30)
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"expiresAt": expiresAt,
+	})
+
+	tokenString, err := token.SignedString([]byte(os.Getenv("JWT_SECRET")))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	cookie := &http.Cookie{
+		Name:     TOKEN_COOKIE_NAME,
+		HttpOnly: true,
+		Secure:   false,
+		Expires:  expiresAt, // 30 days
+		Value:    tokenString,
+		Path:     "/",
+	}
+
+	http.SetCookie(w, cookie)
+}
+
+func Logout(w http.ResponseWriter, r *http.Request) {
+	cookie := &http.Cookie{
+		Name:     TOKEN_COOKIE_NAME,
+		HttpOnly: true,
+		Secure:   false,
+		Expires:  time.Now(),
+		Value:    "",
+		Path:     "/",
+	}
+
+	http.SetCookie(w, cookie)
+}

--- a/server/internal/common.go
+++ b/server/internal/common.go
@@ -66,8 +66,8 @@ type AbortRequest struct {
 // struct representing the intent to start a download
 type DownloadRequest struct {
 	Id     string
-	URL    string
-	Path   string
-	Rename string
-	Params []string
+	URL    string   `json:"url"`
+	Path   string   `json:"path"`
+	Rename string   `json:"rename"`
+	Params []string `json:"params"`
 }

--- a/server/internal/memory_db.go
+++ b/server/internal/memory_db.go
@@ -125,12 +125,18 @@ func (m *MemoryDB) Restore() {
 	}
 
 	for _, proc := range session.Processes {
-		m.table.Store(proc.Id, &Process{
+		restored := &Process{
 			Id:       proc.Id,
 			Url:      proc.Info.URL,
 			Info:     proc.Info,
 			Progress: proc.Progress,
-		})
+		}
+
+		m.table.Store(proc.Id, restored)
+
+		if restored.Progress.Percentage != "-1" {
+			go restored.Start()
+		}
 	}
 
 	log.Println(cli.BgGreen, "Successfully restored session", cli.Reset)

--- a/server/internal/process.go
+++ b/server/internal/process.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/marcopeocchi/fazzoletti/slices"
+	"github.com/marcopeocchi/yt-dlp-web-ui/server/cli"
 	"github.com/marcopeocchi/yt-dlp-web-ui/server/config"
 )
 
@@ -136,8 +137,11 @@ func (p *Process) Start() {
 					Speed:      stdout.Speed,
 					ETA:        stdout.Eta,
 				}
-				shortId := strings.Split(p.Id, "-")[0]
-				log.Printf("[%s] %s %s\n", shortId, p.Url, p.Progress.Percentage)
+				log.Println(
+					cli.BgGreen, "DL", cli.Reset,
+					cli.BgBlue, p.getShortId(), cli.Reset,
+					p.Url, stdout.Percentage,
+				)
 			}
 		}
 	}()
@@ -156,6 +160,14 @@ func (p *Process) Complete() {
 		Speed:      0,
 		ETA:        0,
 	}
+
+	shortId := p.getShortId()
+
+	log.Println(
+		cli.BgMagenta, "FINISH", cli.Reset,
+		cli.BgBlue, shortId, cli.Reset,
+		p.Url,
+	)
 }
 
 // Kill a process and remove it from the memory
@@ -201,6 +213,12 @@ func (p *Process) GetFormatsSync() (DownloadFormats, error) {
 	if err != nil {
 		return DownloadFormats{}, err
 	}
+
+	log.Println(
+		cli.BgRed, "Metadata", cli.Reset,
+		cli.BgBlue, p.getShortId(), cli.Reset,
+		p.Url,
+	)
 
 	go func() {
 		decodingError = json.NewDecoder(stdout).Decode(&info)
@@ -248,6 +266,12 @@ func (p *Process) SetMetadata() error {
 		return err
 	}
 
+	log.Println(
+		cli.BgRed, "Metadata", cli.Reset,
+		cli.BgBlue, p.getShortId(), cli.Reset,
+		p.Url,
+	)
+
 	err = json.NewDecoder(stdout).Decode(&info)
 	if err != nil {
 		return err
@@ -259,4 +283,8 @@ func (p *Process) SetMetadata() error {
 	err = cmd.Wait()
 
 	return err
+}
+
+func (p *Process) getShortId() string {
+	return strings.Split(p.Id, "-")[0]
 }

--- a/server/rest/container.go
+++ b/server/rest/container.go
@@ -1,0 +1,25 @@
+package rest
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/marcopeocchi/yt-dlp-web-ui/server/internal"
+	middlewares "github.com/marcopeocchi/yt-dlp-web-ui/server/middleware"
+)
+
+func Container(db *internal.MemoryDB, mq *internal.MessageQueue) *Handler {
+	var (
+		service = ProvideService(db, mq)
+		handler = ProvideHandler(service)
+	)
+	return handler
+}
+
+func ApplyRouter(db *internal.MemoryDB, mq *internal.MessageQueue) func(chi.Router) {
+	h := Container(db, mq)
+
+	return func(r chi.Router) {
+		r.Use(middlewares.Authenticated)
+		r.Post("/exec", h.Exec())
+		r.Get("/running", h.Running())
+	}
+}

--- a/server/rest/provider.go
+++ b/server/rest/provider.go
@@ -1,0 +1,34 @@
+package rest
+
+import (
+	"sync"
+
+	"github.com/marcopeocchi/yt-dlp-web-ui/server/internal"
+)
+
+var (
+	service *Service
+	handler *Handler
+
+	serviceOnce sync.Once
+	handlerOnce sync.Once
+)
+
+func ProvideService(db *internal.MemoryDB, mq *internal.MessageQueue) *Service {
+	serviceOnce.Do(func() {
+		service = &Service{
+			db: db,
+			mq: mq,
+		}
+	})
+	return service
+}
+
+func ProvideHandler(svc *Service) *Handler {
+	handlerOnce.Do(func() {
+		handler = &Handler{
+			service: svc,
+		}
+	})
+	return handler
+}

--- a/server/rest/service.go
+++ b/server/rest/service.go
@@ -1,0 +1,38 @@
+package rest
+
+import (
+	"context"
+	"errors"
+
+	"github.com/marcopeocchi/yt-dlp-web-ui/server/internal"
+)
+
+type Service struct {
+	db *internal.MemoryDB
+	mq *internal.MessageQueue
+}
+
+func (s *Service) Exec(req internal.DownloadRequest) (string, error) {
+	p := &internal.Process{
+		Url:    req.URL,
+		Params: req.Params,
+		Output: internal.DownloadOutput{
+			Path:     req.Path,
+			Filename: req.Rename,
+		},
+	}
+
+	id := s.db.Set(p)
+	s.mq.Publish(p)
+
+	return id, nil
+}
+
+func (s *Service) Running(ctx context.Context) (*[]internal.ProcessResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, errors.New("context cancelled")
+	default:
+		return s.db.All(), nil
+	}
+}

--- a/server/rpc/container.go
+++ b/server/rpc/container.go
@@ -1,0 +1,24 @@
+package rpc
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/marcopeocchi/yt-dlp-web-ui/server/internal"
+	middlewares "github.com/marcopeocchi/yt-dlp-web-ui/server/middleware"
+)
+
+// Dependency injection container.
+func Container(db *internal.MemoryDB, mq *internal.MessageQueue) *Service {
+	return &Service{
+		db: db,
+		mq: mq,
+	}
+}
+
+// RPC service must be registered before applying this router!
+func ApplyRouter() func(chi.Router) {
+	return func(r chi.Router) {
+		r.Use(middlewares.Authenticated)
+		r.Get("/ws", WebSocket)
+		r.Post("/http", Post)
+	}
+}

--- a/server/rpc/service.go
+++ b/server/rpc/service.go
@@ -24,14 +24,6 @@ type Args struct {
 	Params []string
 }
 
-// Dependency injection container.
-func Container(db *internal.MemoryDB, mq *internal.MessageQueue) *Service {
-	return &Service{
-		db: db,
-		mq: mq,
-	}
-}
-
 // Exec spawns a Process.
 // The result of the execution is the newly spawned process Id.
 func (s *Service) Exec(args internal.DownloadRequest, result *string) error {


### PR DESCRIPTION
# Update: downloads REST API

Hello ✋,

This PR brings a new functionality asked in #70. Since the main focus is using the provided JSON-RPC interface the REST one will only bring limited funtionalities.

Group: **/api/v1**

| Method  | Route  | Description |
|---------|-------|-------------|
| POST  | /exec  | Asynchronously starts a download |
| GET     | /running | Gets running downloads |

### Examples

Start a download using **/exec**:  

```
POST http://localhost:3033/api/v1/exec
```
**Body**
```json
{
  "url": "https://...",
  "params": ["-N", "4", "-R", "infinite"] 
}
```
**Returns**
The id of the download.

## Refactor

The **backend side** has been entirely refactor starting from the last PR: **[fiber](https://gofiber.io/)** has been dropped for the standard library http package.

The reason behind this is because fiber was used soley for it's nice **WebSockets** API. Since I found gorilla's websockets which seamlessly integrates with the http package it was a no brainer.
Moreover I don't like the philosophy behind **fasthttp** package. 🤠 

**Frontend side** sees an improved rendering performance by cutting some unecessary useStates.  
Anyhow is planned to migrate from redux to recoil or another atom base state manager to squeeze more performance.

Hopefully closes #70. 😎 