### PR TITLE
Expose config to docker volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,8 @@
-.parcel-cache
 dist
 package-lock.json
 pnpm-lock.yaml
 .pnpm-debug.log
 node_modules
-src/server/core/*.exe
-src/server/core/yt-dlp
 .env
 *.mp4
 *.ytdl
@@ -16,3 +13,4 @@ downloads
 build/
 yt-dlp-webui
 session.dat
+config.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,26 @@
 FROM golang:1.20-alpine AS build
-# folder structure
+
 WORKDIR /usr/src/yt-dlp-webui
-# install core dependencies
+
 RUN apk update && \
     apk add nodejs npm go
-# copia la salsa
+
 COPY . .
-# build frontend
+
 WORKDIR /usr/src/yt-dlp-webui/frontend
 RUN npm install
 RUN npm run build
-# build backend + incubator
+
 WORKDIR /usr/src/yt-dlp-webui
 RUN CGO_ENABLED=0 GOOS=linux go build -o yt-dlp-webui
 
-# but here yes :)
 FROM alpine:edge
 
 WORKDIR /downloads
 VOLUME /downloads
+
+WORKDIR /config
+VOLUME /config
 
 WORKDIR /app
 
@@ -30,4 +32,9 @@ COPY --from=build /usr/src/yt-dlp-webui/yt-dlp-webui /app
 ENV JWT_SECRET=secret
 
 EXPOSE 3033
-ENTRYPOINT [ "./yt-dlp-webui" , "--out", "/downloads" ]
+
+ENTRYPOINT [ 
+    "./yt-dlp-webui" , 
+    "--out", "/downloads", 
+    "--conf", "/config/config.yml" 
+]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,4 @@ COPY --from=build /usr/src/yt-dlp-webui/yt-dlp-webui /app
 ENV JWT_SECRET=secret
 
 EXPOSE 3033
-
-ENTRYPOINT [ 
-    "./yt-dlp-webui" , 
-    "--out", "/downloads", 
-    "--conf", "/config/config.yml" 
-]
+ENTRYPOINT [ "./yt-dlp-webui" , "--out", "/downloads", "--conf", "/config/config.yml" ]

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/marcopeocchi/yt-dlp-web-ui/server"
+	"github.com/marcopeocchi/yt-dlp-web-ui/server/cli"
 	"github.com/marcopeocchi/yt-dlp-web-ui/server/config"
 )
 
@@ -29,7 +30,7 @@ func init() {
 	flag.IntVar(&port, "port", 3033, "Port where server will listen at")
 	flag.IntVar(&queueSize, "qs", runtime.NumCPU(), "Download queue size")
 
-	flag.StringVar(&configFile, "conf", "", "Config file path")
+	flag.StringVar(&configFile, "conf", "./config.yml", "Config file path")
 	flag.StringVar(&downloadPath, "out", ".", "Where files will be saved")
 	flag.StringVar(&downloaderPath, "driver", "yt-dlp", "yt-dlp executable path")
 
@@ -56,8 +57,9 @@ func main() {
 	c.RequireAuth(requireAuth)
 	c.RPCSecret(rpcSecret)
 
-	if configFile != "" {
-		c.LoadFromFile(configFile)
+	// if config file is found it will be merged with the current config struct
+	if _, err := c.TryLoadFromFile(configFile); err != nil {
+		log.Println(cli.BgRed, "config", cli.Reset, "no config file found")
 	}
 
 	server.RunBlocking(port, frontend)

--- a/server/config/parser.go
+++ b/server/config/parser.go
@@ -22,13 +22,15 @@ type config struct {
 	cfg serverConfig
 }
 
-func (c *config) LoadFromFile(filename string) (serverConfig, error) {
-	bytes, err := os.ReadFile(filename)
+func (c *config) TryLoadFromFile(filename string) (serverConfig, error) {
+	fd, err := os.Open(filename)
 	if err != nil {
 		return serverConfig{}, err
 	}
 
-	yaml.Unmarshal(bytes, &c.cfg)
+	if err := yaml.NewDecoder(fd).Decode(&c.cfg); err != nil {
+		return serverConfig{}, err
+	}
 
 	return c.cfg, nil
 }


### PR DESCRIPTION
# Expose config to a docker volume

As asked, the config file is now accessible by docker.
Just pass to the docker create/run command the volume:

```sh
# as an example
-v /home/user/.config/yt-dlp-webui:/config
```

and move your config file naming it `config.yml` in the mapped folder.