### PR TITLE
bugfix: port config in config file not work 

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 
 	// if config file is found it will be merged with the current config struct
 	if err := c.LoadFile(configFile); err != nil {
-        log.Println(cli.BgRed, "config", cli.Reset, err)
+		log.Println(cli.BgRed, "config", cli.Reset, err)
 	}
 
 	server.RunBlocking(c.Host, c.Port, frontend, localDatabasePath)

--- a/main.go
+++ b/main.go
@@ -76,8 +76,8 @@ func main() {
 
 	// if config file is found it will be merged with the current config struct
 	if err := c.LoadFile(configFile); err != nil {
-		log.Println(cli.BgRed, "config", cli.Reset, "no config file found")
+		log.Println(cli.BgRed, "config", cli.Reset, "config file not found or invalid")
 	}
 
-	server.RunBlocking(host, port, frontend, localDatabasePath)
+	server.RunBlocking(c.Host, c.Port, frontend, localDatabasePath)
 }

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 
 	// if config file is found it will be merged with the current config struct
 	if err := c.LoadFile(configFile); err != nil {
-		log.Println(cli.BgRed, "config", cli.Reset, "config file not found or invalid")
+        log.Println(cli.BgRed, "config", cli.Reset, err)
 	}
 
 	server.RunBlocking(c.Host, c.Port, frontend, localDatabasePath)


### PR DESCRIPTION
Optmize two points:

1. Print more details when failed to load configfile.
    when config exists but content is invalid,currenly always shows configfile not found.This will confuse user and mislead them to wrong debug way. So add more outputs.
3. bugfix:  port configured in configfile not work.