### PR TITLE
i18n: add swedish

### DIFF
--- a/frontend/src/assets/i18n.yaml
+++ b/frontend/src/assets/i18n.yaml
@@ -592,3 +592,57 @@ languages:
     logsTitle: 'Logs'
     awaitingLogs: 'Awaiting logs...'
     bulkDownload: 'Download files in a zip archive'
+  swedish:
+    urlInput: Videolänk (en per rad)
+    statusTitle: Status
+    statusReady: Redo
+    selectFormatButton: Välj format
+    startButton: Start
+    abortAllButton: Avbryt alla
+    updateBinButton: Uppdatera yt-dlp
+    darkThemeButton: Mörkt tema
+    lightThemeButton: Ljust tema
+    settingsAnchor: Inställningar
+    serverAddressTitle: Serveraddress
+    serverPortTitle: Port
+    extractAudioCheckbox: Extrahera ljud
+    noMTimeCheckbox: Lägg inte till info om när filen senast modifierades
+    bgReminder: När du stänger denna sida så kommer nedladdningen att fortsätta i bakgrunden.
+    toastConnected: 'Ansluten till '
+    toastUpdated: Uppdaterade yt-dlp!
+    formatSelectionEnabler: Tillåt val av ljud- och bildformat
+    themeSelect: 'Tema'
+    languageSelect: 'Språk'
+    overridesAnchor: Överskrivningar
+    pathOverrideOption: Tillåt överskrivning av filsökvägen
+    filenameOverrideOption: Tillåt överskrivning av filnamn
+    customFilename: Eget filamn (lämna blankt för standardnamn)
+    customPath: Egen filsökväg
+    customArgs: Tillåt egna yt-dlp-argument (frihet under ansvar!)
+    customArgsInput: Egna yt-dlp-argument
+    rpcConnErr: Ett fel inträffade vid anslutning till RPC-server
+    splashText: Inga pågående nedladdningar
+    archiveTitle: Arkiv
+    clipboardAction: Kopierade länken
+    playlistCheckbox: Ladda ner spellista (detta kommer ta did, efter start så kan du stänga detta fönster)
+    restartAppMessage: En sidomladdning behövs innan förändringen får effekt
+    servedFromReverseProxyCheckbox: Servern befinner sig bakom en omvänd proxy
+    urlBase: URL-bas, behövs för att stödja en omvänd proxy. Standardinställning: lämna tom
+    newDownloadButton: Ny nedladdning
+    homeButtonLabel: Hem
+    archiveButtonLabel: Arkiv
+    settingsButtonLabel: Inställningar
+    rpcAuthenticationLabel: RPC-Autentisering
+    themeTogglerLabel: Tema-knapp
+    loadingLabel: Laddar...
+    appTitle: Apptitel
+    savedTemplates: Sparade mallar
+    templatesEditor: Mallredigerare
+    templatesEditorNameLabel: Namn
+    templatesEditorContentLabel: Innehåll 
+    logsTitle: 'Loggar'
+    awaitingLogs: 'Väntar på loggar...'
+    bulkDownload: 'Ladda ner filer i ett zip-arkiv'
+    rpcPollingTimeTitle: Frekvens av RPC-uppdateringar
+    rpcPollingTimeDescription: En högre frekvens leder kräver mer CPU-resurser för både servern och klienten
+    templatesReloadInfo: För att registrera en ny mall så kan en sidomladdning krävas.

--- a/frontend/src/assets/i18n.yaml
+++ b/frontend/src/assets/i18n.yaml
@@ -616,7 +616,7 @@ languages:
     overridesAnchor: Överskrivningar
     pathOverrideOption: Tillåt överskrivning av filsökvägen
     filenameOverrideOption: Tillåt överskrivning av filnamn
-    customFilename: Eget filamn (lämna blankt för standardnamn)
+    customFilename: Eget filnamn (lämna blankt för standardnamn)
     customPath: Egen filsökväg
     customArgs: Tillåt egna yt-dlp-argument (frihet under ansvar!)
     customArgsInput: Egna yt-dlp-argument
@@ -627,7 +627,7 @@ languages:
     playlistCheckbox: Ladda ner spellista (detta kommer ta did, efter start så kan du stänga detta fönster)
     restartAppMessage: En sidomladdning behövs innan förändringen får effekt
     servedFromReverseProxyCheckbox: Servern befinner sig bakom en omvänd proxy
-    urlBase: URL-bas, behövs för att stödja en omvänd proxy. Standardinställning: lämna tom
+    urlBase: URL-bas, måste anges när en omvänd proxy används. Standardinställning: lämna blank
     newDownloadButton: Ny nedladdning
     homeButtonLabel: Hem
     archiveButtonLabel: Arkiv
@@ -644,5 +644,5 @@ languages:
     awaitingLogs: 'Väntar på loggar...'
     bulkDownload: 'Ladda ner filer i ett zip-arkiv'
     rpcPollingTimeTitle: Frekvens av RPC-uppdateringar
-    rpcPollingTimeDescription: En högre frekvens leder kräver mer CPU-resurser för både servern och klienten
+    rpcPollingTimeDescription: En högre frekvens kräver mer CPU-resurser för både server och klient
     templatesReloadInfo: För att registrera en ny mall så kan en sidomladdning krävas.


### PR DESCRIPTION
This PR adds Swedish internationalization.

When a faithful 1:1 English-Swedish translation would've sounded unnatural, I've sometimes chosen a more terse or more verbose way of expressing the same idea or concept. This is done in order to avoid sounding like jarring "AI-like" literal translations. 