### PR TITLE
feat: K3s - Initial working deployment

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,7 @@
+# Kubernetes
+
+This folder represents deployments for various Kubernetes distributions.
+
+## K3s
+
+K3s uses Traefik internally so this implementation targets it.

--- a/kubernetes/k3s/Chart.yaml
+++ b/kubernetes/k3s/Chart.yaml
@@ -1,0 +1,6 @@
+name: myytdownloader
+type: application
+version: "1.0"
+appVersion: v1.0.0
+apiVersion: v1
+description: Helm chart for yt-dlp-web-ui.

--- a/kubernetes/k3s/charts/yt-downloader/Chart.yaml
+++ b/kubernetes/k3s/charts/yt-downloader/Chart.yaml
@@ -1,0 +1,6 @@
+name: myytdownloader
+type: application
+version: "1.0"
+appVersion: v1.0.0
+apiVersion: v1
+description: Helm chart for yt-dlp-web-ui.

--- a/kubernetes/k3s/charts/yt-downloader/templates/cm.yaml
+++ b/kubernetes/k3s/charts/yt-downloader/templates/cm.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: yt-downloader
+    app.kubernetes.io/instance: yt-downloader
+  name: yt-downloader-cm
+  namespace: yt-downloader
+data:
+  settings: |
+    session_file_path: /session

--- a/kubernetes/k3s/charts/yt-downloader/templates/deployment.yaml
+++ b/kubernetes/k3s/charts/yt-downloader/templates/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yt-downloader-deployment
+  namespace: yt-downloader
+  labels:
+    app.kubernetes.io/name: yt-downloader
+    app.kubernetes.io/instance: yt-downloader
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: yt-downloader
+      app.kubernetes.io/instance: yt-downloader
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: yt-downloader
+        app.kubernetes.io/instance: yt-downloader
+    spec:
+      containers:
+        - name: yt-downloader
+          image: docker.io/marcobaobao/yt-dlp-webui@sha256:5be29ff9b08d8633f47bf1c4084109b8e6a71dfbb41fa974620dbe3324868775
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3033
+              name: app-port
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            runAsGroup: 1000
+            runAsUser: 1001
+          volumeMounts:
+          - name: config-root
+            mountPath: "/config"
+          - name: config-yaml
+            mountPath: "/config/config.yml"
+            subPath: settings
+          - name: downloads
+            mountPath: "/downloads"
+          - name: session
+            mountPath: "/session"
+      volumes:
+        - name: config-root
+          persistentVolumeClaim:
+            claimName: yt-downloader-pvc-config-root
+        - name: config-yaml
+          configMap:
+            name: yt-downloader-cm
+        - name: downloads
+          persistentVolumeClaim:
+            claimName: yt-downloader-pvc-downloads
+        - name: session
+          persistentVolumeClaim:
+            claimName: yt-downloader-pvc-session

--- a/kubernetes/k3s/charts/yt-downloader/templates/ingress.yaml
+++ b/kubernetes/k3s/charts/yt-downloader/templates/ingress.yaml
@@ -1,0 +1,33 @@
+# Awesome - works now with this middleware.
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: strip-double-slash
+  namespace: yt-downloader
+spec:
+  replacePathRegex:
+    regex: /{2,}
+    replacement: /
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: yt-downloader-ingress
+  namespace: yt-downloader
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/websocket: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: kube-system-strip-prefix@kubernetescrd,yt-downloader-strip-double-slash@kubernetescrd
+spec:
+  rules:
+  - host: my.hostname
+    http:
+      paths:
+      - path: /yt
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: yt-downloader-svc
+            port:
+              number: 90
+

--- a/kubernetes/k3s/charts/yt-downloader/templates/pvc.yaml
+++ b/kubernetes/k3s/charts/yt-downloader/templates/pvc.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: yt-downloader
+    app.kubernetes.io/instance: yt-downloader
+  name: yt-downloader-pvc-downloads
+  namespace: yt-downloader
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "250Mi"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: yt-downloader
+    app.kubernetes.io/instance: yt-downloader
+  name: yt-downloader-pvc-session
+  namespace: yt-downloader
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "10Mi"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: yt-downloader
+    app.kubernetes.io/instance: yt-downloader
+  name: yt-downloader-pvc-config-root
+  namespace: yt-downloader
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "10Mi"

--- a/kubernetes/k3s/charts/yt-downloader/templates/service.yaml
+++ b/kubernetes/k3s/charts/yt-downloader/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: yt-downloader-svc
+  namespace: yt-downloader
+  labels:
+    app.kubernetes.io/name: yt-downloader
+    app.kubernetes.io/instance: yt-downloader
+spec:
+  type: ClusterIP
+  ports:
+    - port: 90
+      targetPort: 3033
+  selector:
+    app.kubernetes.io/name: yt-downloader
+    app.kubernetes.io/instance: yt-downloader

--- a/kubernetes/k3s/charts/yt-downloader/templates/traefik-strip-prefix-middleware.yaml
+++ b/kubernetes/k3s/charts/yt-downloader/templates/traefik-strip-prefix-middleware.yaml
@@ -1,0 +1,12 @@
+# This Middleware is necessary to strip prefix for a path in an ingress before forwarding to a service.
+# Without it, the whole path is sent to the service.
+
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: strip-prefix
+  namespace: kube-system # can be anything, but needs ingress.metadata.annotations spec: traefik.ingress.kubernetes.io/router.middlewares: namespace-strip-prefix@kubernetescrd
+spec:
+  stripPrefixRegex:
+    regex:
+    - ^/[^/]+

--- a/kubernetes/k3s/charts/yt-downloader/values.yaml
+++ b/kubernetes/k3s/charts/yt-downloader/values.yaml
@@ -1,0 +1,1 @@
+yt-downloader:

--- a/kubernetes/k3s/values.yaml
+++ b/kubernetes/k3s/values.yaml
@@ -1,0 +1,1 @@
+yt-downloader:


### PR DESCRIPTION
This PR represents an effort to support yt-dlp-web-ui on Kubernetes distributions.

<details>
<summary>Click for screenshots!</summary>
Working after deployment using ArgoCD:

<img width="1722" alt="grafik" src="https://github.com/user-attachments/assets/2a3ff5c1-3b47-43f4-a5d0-e035b513ccbb">

<img width="1714" alt="grafik" src="https://github.com/user-attachments/assets/e1b751a0-f731-47dd-b647-908576bb2cd7">
</details>

It represents a couple of YAML files which can be consumed via Helm.
Currently, no Helm templating is taking place.