### PR TITLE
fix(nix): fix package build

### DIFF
--- a/nix/server.nix
+++ b/nix/server.nix
@@ -1,9 +1,9 @@
-{ yt-dlp-web-ui-frontend, buildGoModule, lib, makeWrapper, yt-dlp, ... }:
+{ yt-dlp-web-ui-frontend, buildGo123Module, lib, makeWrapper, yt-dlp, ... }:
 let
   fs = lib.fileset;
   common = import ./common.nix { inherit lib; };
 in
-buildGoModule {
+buildGo123Module {
   pname = "yt-dlp-web-ui";
   inherit (common) version;
   src = fs.toSource rec {
@@ -26,7 +26,7 @@ buildGoModule {
       # repo commons
       ../.github
       ../README.md
-      ../LICENSE.md
+      ../LICENSE
       ../.gitignore
       ../.vscode
     ]);
@@ -44,7 +44,7 @@ buildGoModule {
       --prefix PATH : ${lib.makeBinPath [ yt-dlp ]}
   '';
 
-  vendorHash = "sha256-guM/U9DROJMx2ctPKBQis1YRhaf6fKvvwEWgswQKMG0=";
+  vendorHash = "sha256-c7IdCmYJEn5qJn3K8wt0qz3t0Nq9rbgWp1eONlCJOwM=";
 
   meta = common.meta // {
     mainProgram = "yt-dlp-web-ui";


### PR DESCRIPTION
With this change, Nix builds will work again. Otherwise they fail with the following error:

```
       error: lib.fileset.unions: Element 10 (/nix/store/sx5qhkm45vkg8wnqcs8k4fa1hzzk3arn-source/LICENSE.md) is a path that does not exist.
           To create a file set from a path that may not exist, use `lib.fileset.maybeMissing`.
```