### PR TITLE
Proposal to fix command line arguments and buggy file rename handling

### DIFF
--- a/frontend/src/lib/rpcClient.ts
+++ b/frontend/src/lib/rpcClient.ts
@@ -71,17 +71,16 @@ export class RPCClient {
       return
     }
 
-    const rename = req.args.includes('-o')
-      ? req.args
-        .substring(req.args.indexOf('-o'))
-        .replaceAll("'", '')
-        .replaceAll('"', '')
-        .split('-o')
-        .map(s => s.trim())
-        .join('')
-        .split(' ')
-        .at(0) ?? ''
-      : ''
+    const argsArr = req.args
+        .match(/(?:[^\s'"\\]|\\.|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")+/g)
+
+    let rename = argsArr?.findIndex((el) => el === '-o' || el === '--output') !== -1
+        ? argsArr[argsArr.findIndex((el) => el === '-o' || el === '--output') + 1]
+        : ''
+
+    if (rename.length) {
+        rename = rename.replace(/^['"]?(.*?)['"]?$/, '$1')
+    }
 
     const sanitizedArgs = this.argsSanitizer(
       req.args

--- a/server/internal/process.go
+++ b/server/internal/process.go
@@ -105,8 +105,12 @@ func (p *Process) Start() {
 
 	// if user asked to manually override the output path...
 	if !(slices.Contains(p.Params, "-P") || slices.Contains(p.Params, "--paths")) {
+		p.Params = append(p.Params, "-P")
+		p.Params = append(p.Params, out.Path)
+	}
+	if !(slices.Contains(p.Params, "-o") || slices.Contains(p.Params, "--output")) {
 		p.Params = append(p.Params, "-o")
-		p.Params = append(p.Params, fmt.Sprintf("%s/%s", out.Path, out.Filename))
+		p.Params = append(p.Params, out.Filename)
 	}
 
 	params := append(baseParams, p.Params...)


### PR DESCRIPTION
I was investigating a problem on my instance because despite having a proper `-o` flag in my templates my files were not renamed properly, and I found out that there was already an issue about it: #300 

This PR is a proposal for a fix. Actually file renaming is not the only problem because the original code is not able to handle arguments containing spaces.

My fix is far from perfect and does not cover the whole problem, but at least now you can use `-o` flag and you get the expected result.