### PR TITLE
Fix typo in bulk download endpoint

### DIFF
--- a/frontend/src/components/HomeSpeedDial.tsx
+++ b/frontend/src/components/HomeSpeedDial.tsx
@@ -41,7 +41,7 @@ const HomeSpeedDial: React.FC<Props> = ({ onDownloadOpen, onEditorOpen }) => {
       <SpeedDialAction
         icon={<FolderZipIcon />}
         tooltipTitle={i18n.t('bulkDownload')}
-        onClick={() => window.open(`${serverAddr}/archive/bulk?token=${localStorage.getItem('token')}`)}
+        onClick={() => window.open(`${serverAddr}/filebrowser/bulk?token=${localStorage.getItem('token')}`)}
       />
       <SpeedDialAction
         icon={<ClearAllIcon />}


### PR DESCRIPTION
I noticed the bulk download feature gave a 404 error, and noticed that this path actually works.
So it appears to just be a minor typo.