### PR TITLE
add deno runtime in docker image to support YouTube downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o yt-dlp-webui
 FROM python:3.13.2-alpine3.21
 
 RUN apk update && \
-apk add ffmpeg ca-certificates curl wget gnutls --no-cache && \
-pip install "yt-dlp[default,curl-cffi,mutagen,pycryptodomex,phantomjs,secretstorage]"
+  apk add ffmpeg ca-certificates curl wget gnutls deno --no-cache && \
+  pip install "yt-dlp[default,curl-cffi,mutagen,pycryptodomex,phantomjs,secretstorage]"
 
 VOLUME /downloads /config
 


### PR DESCRIPTION
as per the [announcement](https://github.com/yt-dlp/yt-dlp/issues/15012) & referencing issue https://github.com/marcopiovanello/yt-dlp-web-ui/issues/350